### PR TITLE
Add ordered items summary

### DIFF
--- a/backend/api/transactions.go
+++ b/backend/api/transactions.go
@@ -175,3 +175,26 @@ func (s *Server) GetTransactions(c echo.Context, params autogen.GetTransactionsP
 	}.VisitGetTransactionsResponse(c.Response())
 	return nil
 }
+
+
+// (GET /transactions/items)
+func (s *Server) GetTransactionsItems(c echo.Context, params autogen.GetTransactionsItemsParams) error {
+	_, err := MustGetAdmin(c)
+	if err != nil {
+		return nil
+	}
+
+	var name string
+	if params.Name != nil {
+		name = string(*params.Name)
+	}
+
+	data, err := s.DBackend.GetAllActiveTransactionsItems(c.Request().Context(), name)
+	if err != nil {
+		logrus.Error(err)
+		return Error500(c)
+	}
+
+	autogen.GetTransactionsItems200JSONResponse(data).VisitGetTransactionsItemsResponse(c.Response())
+	return nil
+}

--- a/backend/internal/db/database.go
+++ b/backend/internal/db/database.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bar/autogen"
 	"bar/internal/models"
 	"context"
 	"time"
@@ -115,6 +116,7 @@ type DBackend interface {
 	CountTransactions(ctx context.Context, account string, state string) (uint64, error)
 
 	GetAllTransactions(ctx context.Context, page uint64, size uint64, state string) ([]*models.Transaction, error)
+	GetAllActiveTransactionsItems(ctx context.Context, name string) ([]autogen.TransactionItem, error)
 	CountAllTransactions(ctx context.Context, state string) (uint64, error)
 
 	// Restock's CRUD

--- a/backend/internal/db/mongo/transaction_misc.go
+++ b/backend/internal/db/mongo/transaction_misc.go
@@ -1,6 +1,7 @@
 package mongo
 
 import (
+	"bar/autogen"
 	"bar/internal/models"
 	"context"
 
@@ -96,4 +97,58 @@ func (b *Backend) CountAllTransactions(ctx context.Context, state string) (uint6
 	}
 
 	return uint64(count), nil
+}
+
+func (b *Backend) GetAllActiveTransactionsItems(ctx context.Context, name string) ([]autogen.TransactionItem, error) {
+	ctx, cancel := b.TimeoutContext(ctx)
+	defer cancel()
+
+	filter := bson.M{"state": autogen.TransactionStarted, "items.state": autogen.TransactionItemStarted}
+
+	if name != "" {
+		filter["name"] = bson.M{"$regex": name, "$options": "i"}
+	}
+
+	cursor, err := b.db.Collection(TransactionsCollection).Aggregate(ctx, []bson.M{
+		{"$match": filter},
+		{
+			"$project": bson.M{
+				"_id":   0,
+				"items": 1,
+			},
+		},
+		{"$unwind": "$items"},
+		{
+			"$group": bson.M{
+				"_id":  "$items.item_id",
+				"item": bson.M{"$first": "$items"},
+				"total_amount": bson.M{
+					"$sum": "$items.item_amount",
+				},
+				"already_done": bson.M{
+					"$sum": "$items.item_already_done",
+				},
+			},
+		},
+		{
+			"$set": bson.M{
+				"item.item_amount": "$total_amount",
+				"item.item_already_done": "$already_done",
+			},
+		},
+		{"$replaceRoot": bson.M{"newRoot": "$item"}},
+		{"$sort": bson.M{"item_amount": -1}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var items []autogen.TransactionItem
+
+	// Decode each item
+	if err := cursor.All(ctx, &items); err != nil {
+		return nil, err
+	}
+
+	return items, nil
 }

--- a/bar.openapi.yml
+++ b/bar.openapi.yml
@@ -1154,6 +1154,49 @@ paths:
         - admin_auth: []
       tags:
         - transactions
+  /transactions/items:
+    get:
+      description: Get all items in active transactions (ordered items)
+      summary: ""
+      operationId: getTransactionsItems
+      parameters:
+        - name: name
+          in: query
+          description: Filter by item name
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TransactionItem"
+        "401":
+          description: "Not authorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "403":
+          description: "Forbidden"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "500":
+          description: "Internal server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+      security:
+        - admin_auth: []
+      tags:
+        - transactions
   /account/transactions:
     get:
       summary: ""

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -8084,6 +8084,43 @@ export const TransactionsApiAxiosParamCreator = function (configuration?: Config
             };
         },
         /**
+         * Get all items in active transactions (ordered items)
+         * @summary 
+         * @param {string} [name] Filter by item name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getTransactionsItems: async (name?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/transactions/items`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication admin_auth required
+
+            if (name !== undefined) {
+                localVarQueryParameter['name'] = name;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Delete transaction
          * @summary 
          * @param {string} accountId ID of the account
@@ -8326,6 +8363,17 @@ export const TransactionsApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Get all items in active transactions (ordered items)
+         * @summary 
+         * @param {string} [name] Filter by item name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getTransactionsItems(name?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TransactionItem>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getTransactionsItems(name, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Delete transaction
          * @summary 
          * @param {string} accountId ID of the account
@@ -8432,6 +8480,16 @@ export const TransactionsApiFactory = function (configuration?: Configuration, b
          */
         getTransactions(page?: number, limit?: number, state?: TransactionState, options?: any): AxiosPromise<GetTransactions200Response> {
             return localVarFp.getTransactions(page, limit, state, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get all items in active transactions (ordered items)
+         * @summary 
+         * @param {string} [name] Filter by item name
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getTransactionsItems(name?: string, options?: any): AxiosPromise<Array<TransactionItem>> {
+            return localVarFp.getTransactionsItems(name, options).then((request) => request(axios, basePath));
         },
         /**
          * Delete transaction
@@ -8543,6 +8601,18 @@ export class TransactionsApi extends BaseAPI {
      */
     public getTransactions(page?: number, limit?: number, state?: TransactionState, options?: AxiosRequestConfig) {
         return TransactionsApiFp(this.configuration).getTransactions(page, limit, state, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get all items in active transactions (ordered items)
+     * @summary 
+     * @param {string} [name] Filter by item name
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof TransactionsApi
+     */
+    public getTransactionsItems(name?: string, options?: AxiosRequestConfig) {
+        return TransactionsApiFp(this.configuration).getTransactionsItems(name, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/frontend/src/lib/components/comptoir/transactionsItems.svelte
+++ b/frontend/src/lib/components/comptoir/transactionsItems.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import type {TransactionItem} from '$lib/api';
+	import { api } from '$lib/config/config';
+	import { transactionsApi } from '$lib/requests/requests';
+	import { onDestroy, onMount } from 'svelte';
+	import { dragscroll } from '@svelte-put/dragscroll';
+	import Autodisconnect from '../random/autodisconnect.svelte';
+
+	let items: Array<TransactionItem> = [];
+    let name: string = "";
+    
+    $: filtered_items = name !== "" ?
+        items.filter((item) => {
+            return item.item_name.toLocaleLowerCase().includes(name.toLocaleLowerCase())
+        }) : items
+    
+	onMount(() => {
+		reloadTransactionsItems();
+	});
+
+	onDestroy(() => {
+	});
+
+	function reloadTransactionsItems() {
+		transactionsApi()
+			.getTransactionsItems(undefined, { withCredentials: true })
+			.then((res) => {
+				if (!(res.data instanceof Array)) return;
+				items = res.data;
+			});
+	}
+</script>
+
+<!-- Good looking dropdown for transaction -->
+<div class="w-full flex justify-center">
+    <!-- show clearly if there's a scrollbar -->
+    <div use:dragscroll class="overflow-auto max-h-[80vh] mt-5">
+        <table class="table-fixed min-w-[60vw] text-center text-xl border-separate border-spacing-y-1 max-h-fit">
+            <thead class="bg-slate-500 sticky top-0">
+                <th class="w-[61%] p-2 flex flex-row justify-items items-center">
+                    <div>Nom</div>
+                    <input class="mx-5 rounded-md p-2 text-black" placeholder="rechercher" bind:value={name}/>
+                </th>
+                <th class="w-[13%]">Commandés</th>
+                <th class="w-[13%]">Terminés</th>
+                <th class="w-[13%]">Restants</th>
+            </thead>
+    
+            <tbody class="overflow-scroll max-h-fit">
+                {#each filtered_items as item}
+                    <tr class="bg-slate-800">
+                        <td class="p-4">
+                            <div class="flex flex-row items-center space-x-5">
+                                <img
+                                    src={api() + item.picture_uri}
+                                    alt="item"
+                                    class="w-10 h-10 rounded-2xl self-center"
+                                />
+                                <div class="">{item.item_name}</div>
+                            </div>
+                        </td>
+                        <td>{item.item_amount}</td>
+                        <td>{item.item_already_done}</td>
+                        <td>{item.item_amount - item.item_already_done}</td>
+                    </tr>
+                {/each}
+    
+            </tbody>
+        </table>
+    </div>
+    
+</div>

--- a/frontend/src/routes/comptoir/c/transactions/+page.svelte
+++ b/frontend/src/routes/comptoir/c/transactions/+page.svelte
@@ -9,6 +9,11 @@
 	import ChangePassword from '$lib/components/comptoir/changePassword.svelte';
 	import Password from '$lib/components/password.svelte';
 
+
+	import { transactionsApi } from '$lib/requests/requests';
+	import type { TransactionItem } from '$lib/api';
+	import TransactionsItems from '$lib/components/comptoir/transactionsItems.svelte';
+
 	function reset() {
 		askForCard = false;
 		askForPassword = false;
@@ -41,6 +46,9 @@
 				goto('/comptoir');
 			});
 	}
+
+	let showTransactionItems = false;
+
 </script>
 
 {#if askForCard}
@@ -127,6 +135,18 @@
 				class="text-3xl bg-blue-700 p-2 rounded-xl hover:bg-blue-900 transition-all"
 				on:click={() => goto('/comptoir/c/refills')}>Historique rechargements</button
 			>
+			{#if showTransactionItems}
+				<button
+					class="text-3xl bg-blue-700 p-2 rounded-xl hover:bg-blue-900 transition-all"
+					on:click={() => showTransactionItems = false}>Liste des commandes</button
+				>
+			{:else}
+				<button
+					class="text-3xl bg-blue-700 p-2 rounded-xl hover:bg-blue-900 transition-all"
+					on:click={() => showTransactionItems = true}>Résumé des commandes</button
+				>
+			{/if}
+			
 			<button
 				class="text-3xl bg-blue-700 p-2 rounded-xl hover:bg-blue-900 transition-all mr-2"
 				on:click={() => (newRefill = true)}>Nouvelle Recharge</button
@@ -141,7 +161,11 @@
 		</div>
 		<hr class="col-span-3" />
 
-		<Transactions amount={6} />
+		{#if showTransactionItems}
+			<TransactionsItems />
+		{:else}
+			<Transactions amount={6} />
+		{/if}
 
 		{#if newRefill}
 			<NewRefill {close} />


### PR DESCRIPTION
Rajoute un bouton sur la page `/comptoir/c/transactions` pour afficher une liste de tous les produits des commandes qui ne sont pas encore terminées.

- Ajoute l'endpoint `GET /transactions/items`
- Ajoute le composant `transactionsItems` dans le frontend

Génère avec une aggrégation une liste des produits en cours de commande, triée par nombre de produit commandé, et réutilise le schéma d'un `TransactionItem` pour les résultats
