### PR TITLE
Add confirmation popups

### DIFF
--- a/frontend/src/lib/components/confirmationPopup.svelte
+++ b/frontend/src/lib/components/confirmationPopup.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	export let message: string = "Voulez-vous vraiment faire ceci ?";
+    export let confirm_text: string = "Confirmer";
+    export let cancel_text: string = "Annuler";
+    export let cancel_callback: VoidFunction;
+    export let confirm_callback: VoidFunction;
+</script>
+
+<!-- Display a popup that asks to confirm an action -->
+
+<button
+	id="overlay"
+	class="absolute w-full h-full top-0 left-0 bg-black bg-opacity-50 flex justify-center items-center z-40"
+    on:click={cancel_callback}
+/>
+
+<div id="popup" class="absolute w-full h-full top-0 left-0 flex justify-center items-center">
+	<div class="flex flex-col items-center bg-slate-700 rounded-lg shadow-lg p-6 z-40 space-y-5 max-w-[30vw]">
+		<h1 class="text-2xl font-bold text-white">{message}</h1>
+        <div class="flex flex-row w-full justify-end space-x-5">
+            <button on:click={cancel_callback} class="bg-slate-400 text-black rounded-md p-4">{cancel_text}</button>
+            <button on:click={confirm_callback} class="bg-red-500 text-black rounded-md p-4">{confirm_text}</button>
+        </div>
+	</div>
+</div>

--- a/frontend/src/routes/admin/accounts/+page.svelte
+++ b/frontend/src/routes/admin/accounts/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Account, NewAccount, NewCategory } from '$lib/api';
 	import Refills from '$lib/components/admin/refills.svelte';
+	import ConfirmationPopup from '$lib/components/confirmationPopup.svelte';
 	import { accountsApi } from '$lib/requests/requests';
 	import { formatPrice } from '$lib/utils';
 	import { onMount } from 'svelte';
@@ -33,6 +34,10 @@
 	};
 	let accounts_per_page = 10;
 	let shown_refill: Account | undefined = undefined;
+
+	let deletingAccount: boolean = false;
+	let confirmationMessage: string | undefined = undefined;
+	let deleteAccountCallback: VoidFunction = () => {};
 
 	onMount(() => {
 		reloadAccounts();
@@ -193,6 +198,18 @@
 		</div>
 	</div>
 </div>
+
+
+{#if deletingAccount}
+	<ConfirmationPopup
+		message={confirmationMessage}
+		confirm_text="Supprimer"
+		cancel_callback={() => {
+			deletingAccount = false;
+		}} 
+		confirm_callback={deleteAccountCallback}
+	/>
+{/if}
 
 <!-- Table Section -->
 <div class="max-w-[95%] px-4 py-10 sm:px-6 lg:px-8 lg:py-14 mx-auto">
@@ -526,7 +543,14 @@
 											</button>
 											<button
 												class="inline-flex items-center gap-x-1.5 text-sm text-blue-600 decoration-2 hover:underline font-medium"
-												on:click={() => deleteAccount(account.id)}
+												on:click={() => {
+													deleteAccountCallback = () => {
+														deletingAccount = false;
+														deleteAccount(account.id);
+													}
+													confirmationMessage = "Supprimer le compte de " + account.first_name + " " + account.last_name + " ?";
+													deletingAccount = true;
+												}}
 											>
 												Supprimer
 											</button>

--- a/frontend/src/routes/admin/carousel/images/+page.svelte
+++ b/frontend/src/routes/admin/carousel/images/+page.svelte
@@ -3,12 +3,16 @@
 	import { api } from '$lib/config/config';
 	import { carouselApi } from '$lib/requests/requests';
 	import { onMount } from 'svelte';
+	import ConfirmationPopup from '$lib/components/confirmationPopup.svelte';
 
 	let carouselImages: CarouselImage[] = [];
 	let newImage: File | null = null;
 
 	let page = 0;
 	let imagesPerPage = 10;
+
+	let showConfirmation: boolean = false;
+	let confirmationCallback: VoidFunction = () => {}
 
 	onMount(() => {
 		carouselApi()
@@ -123,6 +127,17 @@
 	</div>
 </div>
 
+{#if showConfirmation}
+	<ConfirmationPopup
+		message="Supprimer cette image ?"
+		confirm_text="Supprimer"
+		cancel_callback={() => {
+			showConfirmation = false;
+		}} 
+		confirm_callback={confirmationCallback}
+	/>
+{/if}
+
 <!-- Table Section -->
 <div class="max-w-[85rem] px-4 py-10 sm:px-6 lg:px-8 lg:py-14 mx-auto">
 	<!-- Card -->
@@ -204,7 +219,13 @@
 										<div class="px-6 py-1.5">
 											<button
 												class="inline-flex items-center gap-x-1.5 text-sm text-blue-600 decoration-2 hover:underline font-medium"
-												on:click={() => deleteCarouselImage(carouselImage.id)}
+												on:click={() => {
+													confirmationCallback = () => {
+														showConfirmation = false;
+														deleteCarouselImage(carouselImage.id)
+													}
+													showConfirmation = true;
+												}}
 											>
 												Supprimer
 											</button>

--- a/frontend/src/routes/admin/carousel/textes/+page.svelte
+++ b/frontend/src/routes/admin/carousel/textes/+page.svelte
@@ -2,6 +2,7 @@
 	import type { CarouselText, CarouselTextCreate } from '$lib/api';
 	import { carouselApi } from '$lib/requests/requests';
 	import { onMount } from 'svelte';
+	import ConfirmationPopup from '$lib/components/confirmationPopup.svelte';
 
 	let allCarouselTexts: CarouselText[] = [];
 	let carouselTexts: CarouselText[] = [];
@@ -13,6 +14,9 @@
 	let searchQuery = '';
 	let page = 0;
 	let textsPerPage = 10;
+
+	let showConfirmation: boolean = false;
+	let confirmationCallback: VoidFunction = () => {}
 
 	onMount(() => {
 		carouselApi()
@@ -116,6 +120,17 @@
 		</div>
 	</div>
 </div>
+
+{#if showConfirmation}
+	<ConfirmationPopup
+		message="Supprimer ce texte ?"
+		confirm_text="Supprimer"
+		cancel_callback={() => {
+			showConfirmation = false;
+		}} 
+		confirm_callback={confirmationCallback}
+	/>
+{/if}
 
 <!-- Table Section -->
 <div class="max-w-[85rem] px-4 py-10 sm:px-6 lg:px-8 lg:py-14 mx-auto">
@@ -255,7 +270,13 @@
 										<div class="px-6 py-1.5">
 											<button
 												class="inline-flex items-center gap-x-1.5 text-sm text-blue-600 decoration-2 hover:underline font-medium"
-												on:click={() => deleteCarouselText(carouselText.id)}
+												on:click={() => {
+													confirmationCallback = () => {
+														showConfirmation = false;
+														deleteCarouselText(carouselText.id);
+													}
+													showConfirmation = true;
+												}}
 											>
 												Supprimer
 											</button>

--- a/frontend/src/routes/admin/categories/+page.svelte
+++ b/frontend/src/routes/admin/categories/+page.svelte
@@ -2,6 +2,7 @@
 	import type { Category, NewCategory } from '$lib/api';
 	import { api } from '$lib/config/config';
 	import { categoriesApi } from '$lib/requests/requests';
+	import ConfirmationPopup from '$lib/components/confirmationPopup.svelte';
 	import { onMount } from 'svelte';
 
 	let categories: Category[] = [];
@@ -14,6 +15,10 @@
 
 	let page = 0;
 	let categoriesPerPage = 10;
+
+	let deletingCategory: boolean = false;
+	let confirmationMessage: string | undefined = undefined;
+	let deleteCategoryCallback: VoidFunction = () => {};
 
 	onMount(() => {
 		categoriesApi()
@@ -169,6 +174,17 @@
 	</div>
 </div>
 
+{#if deletingCategory}
+	<ConfirmationPopup
+		message={confirmationMessage}
+		confirm_text="Supprimer"
+		cancel_callback={() => {
+			deletingCategory = false;
+		}} 
+		confirm_callback={deleteCategoryCallback}
+	/>
+{/if}
+
 <!-- Table Section -->
 <div class="max-w-[85rem] px-4 py-10 sm:px-6 lg:px-8 lg:py-14 mx-auto">
 	<!-- Card -->
@@ -314,7 +330,14 @@
 										<div class="px-6 py-1.5">
 											<button
 												class="inline-flex items-center gap-x-1.5 text-sm text-blue-600 decoration-2 hover:underline font-medium"
-												on:click={() => deleteCategory(category.id)}
+												on:click={() => {
+													deleteCategoryCallback = () => {
+														deletingCategory = false;
+														deleteCategory(category.id)
+													}
+													confirmationMessage = "Supprimer '" + category.name + "' ?";
+													deletingCategory = true;
+												}}
 											>
 												Supprimer
 											</button>

--- a/frontend/src/routes/admin/produits/+page.svelte
+++ b/frontend/src/routes/admin/produits/+page.svelte
@@ -8,6 +8,7 @@
 		AccountPriceRole,
 		ItemState
 	} from '$lib/api';
+	import ConfirmationPopup from '$lib/components/confirmationPopup.svelte';
 	import { api } from '$lib/config/config';
 	import { categoriesApi, itemsApi } from '$lib/requests/requests';
 	import { formatPrice, parsePrice } from '$lib/utils';
@@ -63,6 +64,10 @@
 	let searchState: ItemState | undefined = undefined;
 	let searchCategory: string | undefined = undefined;
 	let searchName: string | undefined = undefined;
+
+	let deletingItem: boolean = false;
+	let confirmationMessage: string | undefined = undefined;
+	let deleteItemCallback: VoidFunction = () => {};
 
 	onMount(() => {
 		categoriesApi()
@@ -458,6 +463,17 @@
 	</div>
 </div>
 
+{#if deletingItem}
+	<ConfirmationPopup 
+		message={confirmationMessage}
+		confirm_text="Supprimer"
+		cancel_callback={() => {
+			deletingItem = false;
+		}} 
+		confirm_callback={deleteItemCallback}
+	/>
+{/if}
+
 <!-- Table Section -->
 <div class="max-w-[95%] px-4 py-10 sm:px-6 lg:px-8 lg:py-14 mx-auto">
 	<!-- Card -->
@@ -839,7 +855,14 @@
 											</button>
 											<button
 												class="inline-flex items-center gap-x-1.5 text-sm text-blue-600 decoration-2 hover:underline font-medium"
-												on:click={() => deleteItem(item.id, item.category_id)}
+												on:click={() => {
+													deleteItemCallback = () => {
+														deletingItem = false;
+														deleteItem(item.id, item.category_id);
+													}
+													confirmationMessage = "Supprimer '" + item.name + "' ?";
+													deletingItem = true;
+												}}
 											>
 												Supprimer
 											</button>


### PR DESCRIPTION
Ajoute des popups de confirmation lors de la suppression sur le panel admin.

- Ajoute le composant `confirmationPopup`
- Ajoute un popup de confirmation lors de la suppression sur les pages suivantes :
    - `/admin/accounts`
    - `/admin/categories`
    - `/admin/produits`
    - `/admin/carousel/textes`
    - `/admin/carousel/images`