### PR TITLE
fix(front): Change refill type by default to card instead of other in card declaration

### DIFF
--- a/frontend/src/lib/components/comptoir/newRefill.svelte
+++ b/frontend/src/lib/components/comptoir/newRefill.svelte
@@ -18,7 +18,7 @@
 	let card = {
 		id: '',
 		amount: 0,
-		type: RefillType.RefillOther
+		type: RefillType.RefillCard
 	};
 </script>
 


### PR DESCRIPTION
Hotfix to change to the default option for new refill that was by default other and now is card. The bug was that the option order were changed but not the declaration of card.