### PR TITLE
fix(front): Inverted enum name and values

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -55,8 +55,11 @@ export const time2Utc = (time: number): number => {
     return time + delta;
 }
 
-export const enumIterator = (e: any): Iterable<[key: string, value: string]> => {
-    return Object.entries(Fournisseur).map(([key, value]) => {return [key, formatEnumName(value)]});
+export const enumIterator = (e: any): Iterable<[value: string, name: string]> => {
+    return Object.entries(Fournisseur).map(([key, value]) => {
+        console.log("Key : " + key + " val : " + value)
+        return [value, formatEnumName(key)]
+    });
 }
 
 export const formatEnumName = (name: string): string => {


### PR DESCRIPTION
La PR #142 inverse les valeurs et les noms des enum `RestockType` et `Fournisseur` dans le front, qui ne correspondent donc plus avec les anciennes valeurs de l'enum.