### PR TITLE
fix(front):set french date format for refills history

### DIFF
--- a/frontend/src/routes/panel/treso/recharges/+page.svelte
+++ b/frontend/src/routes/panel/treso/recharges/+page.svelte
@@ -61,9 +61,9 @@
 				type="date"
 				value={todayMorning.toLocaleString('default', { year: 'numeric' }) +
 					'-' +
-					todayMorning.toLocaleString('default', { month: '2-digit' }) +
+					todayMorning.toLocaleString('default', { day: '2-digit' }) +
 					'-' +
-					todayMorning.toLocaleString('default', { day: '2-digit' })}
+					todayMorning.toLocaleString('default', { month: '2-digit' })}
 				on:change={(e) => {
 					// @ts-ignore
 					let s = time2Utc(new Date(e.target.value).getTime() / 1000);


### PR DESCRIPTION
Dans l'historique des rechargements, le jour et le mois par défaut étaient inversés, ainsi la date par défaut était inversé jusqu'au 12 du mois, puis elle ne s'initialisait plus. 