### PR TITLE
Fix divide by zero error in restock process

### DIFF
--- a/backend/api/utils.go
+++ b/backend/api/utils.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
 )
 
 func (s *Server) SetCookie(c echo.Context, account *models.Account) {
@@ -107,6 +108,10 @@ func MustGetAdmin(c echo.Context) (*models.Account, error) {
 
 func UpdateItem(item *models.Item, category *models.Category, restockItem autogen.RestockItem) *models.Item {
 	item.State = autogen.ItemBuyable
+	if restockItem.AmountPerBundle == 0 {
+		restockItem.AmountPerBundle = 1
+		logrus.WithField("restockItem", restockItem.ItemName).Error("AmountPerBundle is 0, setting to 1")
+	} 
 	item.AmountLeft += restockItem.AmountOfBundle * restockItem.AmountPerBundle
 	item.LastTva = &restockItem.Tva
 	if !category.SpecialPrice {


### PR DESCRIPTION
Adjust the `AmountPerBundle` to 1 when it is zero and log a warning to prevent potential divide by zero errors during item updates.