### PR TITLE
fix(courses): correct limit on Mongo Aggregation of products

### DIFF
--- a/backend/api/course.go
+++ b/backend/api/course.go
@@ -20,7 +20,7 @@ func (s *Server) GetCourse(c echo.Context, params autogen.GetCourseParams) error
 	}
 	var course []autogen.CourseItem
 
-	data, err := s.DBackend.GetItems(c.Request().Context(), "", 0, 0, "", "", search, false)
+	data, err := s.DBackend.GetItems(c.Request().Context(), "", 0, 1000, "", "", search, false)
 	if err != nil {
 		logrus.Error(err)
 		return Error500(c)


### PR DESCRIPTION
# Summary

Fixes the course API : limit of 0 was set on the items aggregation for mongoDB which crashes the API
Now this limit is 1000, this should be enough for any "réappro" (coucou c'est la log)
---

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please add the corresponding labels to your pull request -->
- [x] Bug fix (non-breaking change which fixes an issue)            <!-- bug -->
- [ ] New feature (non-breaking change which adds functionality)    <!-- enhancement -->
- [ ] Documentation (update or create documentation)                <!-- documentation -->
- [ ] CI/CD                                                         <!-- CI/CD -->
- [ ] Other
<!-- Don't forget to add the "breaking change" label ! -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  <!-- breaking change -->
